### PR TITLE
Fix filename for module

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/stimulus-components/stimulus-carousel",
   "private": false,
   "main": "dist/stimulus-carousel.umd.js",
-  "module": "dist/stimulus-carousel.es.js",
+  "module": "dist/stimulus-carousel.mjs",
   "scripts": {
     "format": "prettier-standard  '**/*.{ts,css,html}' --format",
     "lint": "prettier-standard  '**/*.{ts,css,html}' --lint",


### PR DESCRIPTION
I could only find the file "stimulus-carousel.umd.js" and "stimulus-carousel.mjs" in the node_modules "dist/" folder so I guess the file extension "es.js" should be changed to "mjs".

This change fixed the following issue for me when using the latest symfony/webpack-encore and stimulus-bridge with latest stimulus version:

```
Error connecting controller

TypeError: t is not a constructor
    at extended.connect (stimulus-carousel.umd.js:1:380)
    at Context.connect (stimulus.js:1379:1)
    at Module.connectContextForScope (stimulus.js:1549:1)
    at stimulus.js:1936:1
    at Array.forEach (<anonymous>)
    at Router.connectModule (stimulus.js:1936:1)
    at Router.loadDefinition (stimulus.js:1895:1)
    at stimulus.js:2000:1
    at Array.forEach (<anonymous>)
    at Application.load (stimulus.js:1998:1)

{identifier: 'carousel', controller: extended, element: div.swiper.-mx-16.md:mx-0}

```